### PR TITLE
It is enough to set the git repo's user

### DIFF
--- a/patch/patch.sh
+++ b/patch/patch.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ex
 
-git config --global user.name "John Doe"
-git config --global user.email "johndoe@example.com"
+git config user.name "John Doe"
+git config user.email "johndoe@example.com"
 
 function git_cherry_pick ()
 {


### PR DESCRIPTION
Instead of modifying the global config,
only set the dummy user in the git repo
where the patches are applied.
This way the global user setting is kept.