### PR TITLE
Exit `update-dependent-repositories` workflow if a dependent repo doesn't have `govpp` dependency

### DIFF
--- a/.github/workflows/update-dependent-repositories.yaml
+++ b/.github/workflows/update-dependent-repositories.yaml
@@ -62,6 +62,12 @@ jobs:
       - name: Update ${{ matrix.repository }} locally
         working-directory: networkservicemesh/${{ matrix.repository }}
         run: |
+          has_dep=$(grep "github.com/${{ github.repository }}" go.mod | grep -v "// indirect" -c)
+          if [ "$has_dep" -eq 0 ]; then
+            echo "${{ matrix.repository }} repo doesn't have ${{ github.repository }} dependency"
+            exit 0
+          fi
+
           go get -u github.com/${{ github.repository }}@${{ github.sha }}
           go mod tidy
           git diff


### PR DESCRIPTION
## Issue
https://github.com/networkservicemesh/.github/issues/61