### PR TITLE
Update dependent repositories fix

### DIFF
--- a/.github/workflows/update-dependent-repositories.yaml
+++ b/.github/workflows/update-dependent-repositories.yaml
@@ -62,6 +62,7 @@ jobs:
       - name: Update ${{ matrix.repository }} locally
         working-directory: networkservicemesh/${{ matrix.repository }}
         run: |
+          set +e
           has_dep=$(grep "github.com/${{ github.repository }}" go.mod | grep -v "// indirect" -c)
           if [ "$has_dep" -eq 0 ]; then
             echo "${{ matrix.repository }} repo doesn't have ${{ github.repository }} dependency"


### PR DESCRIPTION
### Description

Update dependent repositories: don't exit immediately if a command exits with a non-zero status.
`grep` may return `1`

See: https://github.com/networkservicemesh/govpp/actions/runs/8252757728
