### PR TITLE
Fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV GOBIN=/bin
 ARG GOVPP_VERSION
 RUN go install go.fd.io/govpp/cmd/binapi-generator@${GOVPP_VERSION}
 
-FROM alpine:3.18 as gen
+FROM alpine:3.20 as gen
 COPY --from=vpp /usr/share/vpp/api/ /usr/share/vpp/api/
 COPY --from=binapi-generator /bin/binapi-generator /bin/binapi-generator
 COPY --from=vppbuild /vpp/VPP_VERSION /VPP_VERSION


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/deployments-k8s/issues/12283

Fixing: https://github.com/networkservicemesh/deployments-k8s/security/code-scanning/25349 as base image for cmd-forwarder-vpp and some others

After local test: ubuntu image 20.04 has been updated and all high kernel based CVEs has been removed. So, no need to bump it. Also, latest ubuntu doesn't contain some required libs for build.